### PR TITLE
Add app window frame

### DIFF
--- a/src/components/AppWindowFrame/AppWindowFrame.tsx
+++ b/src/components/AppWindowFrame/AppWindowFrame.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import theme from "../../theme";
+
+type Props = {
+  children: React.ReactNode;
+  frameColor: string;
+  backgroundColor?: string;
+  title?: string;
+};
+
+const Frame = styled(Box)({
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  width: "100%",
+  height: "2rem",
+  minHeight: "2rem",
+});
+
+const FrameSection = styled(Box)({
+  display: "flex",
+  minWidth: "5rem",
+  alignItems: "center",
+});
+
+const CircleButton = styled(Box)({
+  display: "flex",
+  borderRadius: "50%",
+  height: "0.75rem",
+  width: "0.75rem",
+  margin: "0 4px",
+});
+
+const Title = styled(Typography)({
+  padding: "0 3rem",
+  fontSize: "0.85rem",
+  fontWeight: "bold",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+  textOverflow: "ellipsis",
+});
+
+const MainContentsContainer = styled(Box)({
+  flexGrow: 1,
+});
+
+const redButtonColor = "#EE695E";
+const yellowButtonColor = "#F4BE4F";
+const greenButtonColor = "#62C554";
+
+function AppWindowFrame({ children, frameColor, backgroundColor = "#ffffff", title }: Props) {
+  return (
+    <Box
+      display={"flex"}
+      flexDirection={"column"}
+      height={"100%"}
+    >
+      <Frame bgcolor={frameColor}>
+        <FrameSection justifyContent={"left"}>
+          <Box
+            display={"flex"}
+            flexDirection={"row"}
+            alignItems={"center"}
+            justifyContent={"center"}
+            marginLeft={"0.5rem"}
+          >
+            <CircleButton bgcolor={redButtonColor} />
+            <CircleButton bgcolor={yellowButtonColor} />
+            <CircleButton bgcolor={greenButtonColor} />
+          </Box>
+        </FrameSection>
+
+        <FrameSection justifyContent={"center"} flexGrow={1}>
+          <Title
+            sx={{
+              color: theme.palette.getContrastText(frameColor),
+            }}
+          >
+            {title}
+          </Title>
+        </FrameSection>
+
+        {/*  Just a placeholder to divide item containers in perfect thirds.  */}
+        <FrameSection justifyContent={"right"} />
+      </Frame>
+
+      <MainContentsContainer bgcolor={backgroundColor}>
+        {children}
+      </MainContentsContainer>
+    </Box>
+  );
+}
+
+export default AppWindowFrame;

--- a/src/components/AppWindowFrame/AppWindowFrame.tsx
+++ b/src/components/AppWindowFrame/AppWindowFrame.tsx
@@ -17,6 +17,7 @@ const Frame = styled(Box)({
   width: "100%",
   height: "2rem",
   minHeight: "2rem",
+  // position: "fixed",   // Fix frame to stick to top of screen.
 });
 
 const FrameSection = styled(Box)({

--- a/src/components/AppWindowFrame/index.js
+++ b/src/components/AppWindowFrame/index.js
@@ -1,0 +1,3 @@
+import AppWindowFrame from "./AppWindowFrame";
+
+export default AppWindowFrame;

--- a/src/components/Dock/Dock.tsx
+++ b/src/components/Dock/Dock.tsx
@@ -31,8 +31,7 @@ const WindowContainer = styled(Box)({
   margin: "0.5vw",
   flexGrow: 1,
   boxShadow: "0px 0px 4px 4px rgba(0,0,0,0.20)",
-  border: "1px solid #FFFFFF40",
-  backgroundColor: "#FFFFFF",
+  border: "0.5px solid #FFFFFF40",
 });
 
 const DockContainer = styled("div")({

--- a/src/pages/DemoPage/DemoPage.tsx
+++ b/src/pages/DemoPage/DemoPage.tsx
@@ -4,6 +4,7 @@ import { ScenarioContext } from "../../contexts/ScenarioContextProvider";
 import useGet from "../../hooks/useGet";
 import { Button } from "@mui/material";
 import useNotifications from "../../hooks/useNotifications";
+import AppWindowFrame from "../../components/AppWindowFrame";
 
 function DemoPage() {
   const [greeting, setGreeting] = useState<string | undefined>(undefined);
@@ -35,7 +36,7 @@ function DemoPage() {
   const { showNotification } = useNotifications();
 
   return (
-    <div>
+    <AppWindowFrame frameColor={"#270C29"} title={"Demo Page"} >
       <h1>HomePage</h1>
       <h3>{greeting ?? "greeting"}</h3>
       <button onClick={handleInitRepo} style={{ margin: 10 }}>
@@ -73,7 +74,7 @@ function DemoPage() {
       }}>
         launch notification.
       </Button>
-    </div>
+    </AppWindowFrame>
   );
 }
 


### PR DESCRIPTION
Adds app window frame for application windows involved in scenarios.
Currently has an issue where top frame is not stuck to the top of the screen and instead is a part of page.
Possible fix for this could be using AppBar component in MUI (https://mui.com/material-ui/react-app-bar/)

Fixes #18 