### PR TITLE
Implement vscode screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
+    "@vscode/codicons": "^0.0.31",
+    "@vscode/webview-ui-toolkit": "^1.0.0",
     "axios": "^0.27.2",
     "dotenv": "^16.0.1",
     "react": "^18.2.0",

--- a/src/components/VSCodeExplorer/VSCodeExplorer.tsx
+++ b/src/components/VSCodeExplorer/VSCodeExplorer.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionProps,
+  AccordionSummary,
+  AccordionSummaryProps,
+  Box,
+  Typography
+} from "@mui/material";
+import { VSCODE_COLORS } from "../../theme/colors";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp";
+import { styled } from "@mui/material/styles";
+
+type Props = {
+//  So far, no props but add when need rises at a later date.
+};
+
+const ExplorerSectionContainer = styled((props: AccordionProps) => (
+  <Accordion square disableGutters elevation={0} {...props} />
+))(({ theme }) => ({
+  backgroundColor: "inherit",
+  color: "inherit",
+  border: `1px solid ${theme.palette.divider}`,
+  "&:not(:last-child)": {
+    borderBottom: 0,
+  },
+  "&:before": {
+    display: "none",
+  },
+}));
+
+const ExplorerSectionSummary = styled((props: AccordionSummaryProps) => (
+  <AccordionSummary
+    expandIcon={<ArrowForwardIosSharpIcon
+      fontSize={"small"}
+      sx={{ color: VSCODE_COLORS.explorerText }}
+    />}
+    {...props}
+  />
+))(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  flexDirection: "row-reverse",
+  "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
+    transform: "rotate(90deg)",
+  },
+  "& .MuiAccordionSummary-content": {
+    marginLeft: theme.spacing(1),
+  },
+}));
+
+function VSCodeExplorer({}: Props) {
+  return (
+    <Box
+      display={"flex"}
+      flexDirection={"column"}
+      height={"100%"}
+      width={"25vw"}
+      bgcolor={VSCODE_COLORS.explorerGrey}
+      color={VSCODE_COLORS.explorerText}
+    >
+      <Box
+        display={"flex"}
+        padding={"0.5rem 1rem"}
+        justifyContent={"space-between"}
+      >
+        <Typography
+          variant={"caption"}
+          fontSize={"1rem"}
+          textTransform={"uppercase"}
+        >
+          Explorer
+        </Typography>
+        <MoreHorizIcon fontSize={"medium"} />
+      </Box>
+      <ExplorerSectionContainer>
+        <ExplorerSectionSummary>
+          <Typography
+            variant={"caption"}
+            fontSize={"1rem"}
+            textTransform={"uppercase"}
+          >
+            Open Editors
+          </Typography>
+        </ExplorerSectionSummary>
+        <AccordionDetails>
+          <Typography>Main.java</Typography>
+        </AccordionDetails>
+      </ExplorerSectionContainer>
+    </Box>
+  );
+}
+
+export default VSCodeExplorer;

--- a/src/components/VSCodeExplorer/VSCodeExplorer.tsx
+++ b/src/components/VSCodeExplorer/VSCodeExplorer.tsx
@@ -1,57 +1,41 @@
 import React from "react";
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionProps,
-  AccordionSummary,
-  AccordionSummaryProps,
   Box,
   Typography
 } from "@mui/material";
 import { VSCODE_COLORS } from "../../theme/colors";
-import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
-import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp";
 import { styled } from "@mui/material/styles";
+import VSCodeIcon from "../VSCodeIcon";
+import { File } from "../../types/FileTypes";
+import VSCodeExplorerFiles from "./VSCodeExplorerFiles";
 
 type Props = {
-//  So far, no props but add when need rises at a later date.
+  files?: File[];
 };
 
-const ExplorerSectionContainer = styled((props: AccordionProps) => (
-  <Accordion square disableGutters elevation={0} {...props} />
-))(({ theme }) => ({
-  backgroundColor: "inherit",
-  color: "inherit",
-  border: `1px solid ${theme.palette.divider}`,
-  "&:not(:last-child)": {
-    borderBottom: 0,
-  },
-  "&:before": {
-    display: "none",
-  },
-}));
-
-const ExplorerSectionSummary = styled((props: AccordionSummaryProps) => (
-  <AccordionSummary
-    expandIcon={<ArrowForwardIosSharpIcon
-      fontSize={"small"}
-      sx={{ color: VSCODE_COLORS.explorerText }}
-    />}
-    {...props}
-  />
-))(({ theme }) => ({
+const ExplorerSectionSummary = styled(Box)({
   display: "flex",
   alignItems: "center",
-  flexDirection: "row-reverse",
-  "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
-    transform: "rotate(90deg)",
-  },
-  "& .MuiAccordionSummary-content": {
-    marginLeft: theme.spacing(1),
-  },
-}));
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  borderTop: `1px solid ${VSCODE_COLORS.explorerDivider}`,
+  padding: "0.1rem 0",
+});
 
-function VSCodeExplorer({}: Props) {
+const ExplorerSectionSummaryHeader = styled(Typography)({
+  fontSize: "0.75rem",
+  fontWeight: 800,
+  marginRight: 1,
+  color: VSCODE_COLORS.explorerText,
+  textTransform: "uppercase",
+  userSelect: "none",
+});
+
+const ExplorerSectionSummaryIconStyle = {
+  width: "1.2rem",
+};
+
+function VSCodeExplorer({ files }: Props) {
   return (
     <Box
       display={"flex"}
@@ -61,34 +45,50 @@ function VSCodeExplorer({}: Props) {
       bgcolor={VSCODE_COLORS.explorerGrey}
       color={VSCODE_COLORS.explorerText}
     >
+
+      {/*  Explorer title section  */}
       <Box
         display={"flex"}
-        padding={"0.5rem 1rem"}
+        padding={"0.5rem 1.2rem"}
         justifyContent={"space-between"}
       >
         <Typography
-          variant={"caption"}
-          fontSize={"1rem"}
+          fontSize={"0.75rem"}
           textTransform={"uppercase"}
+          fontWeight={500}
         >
           Explorer
         </Typography>
-        <MoreHorizIcon fontSize={"medium"} />
+        <VSCodeIcon iconName={"ellipsis"} />
       </Box>
-      <ExplorerSectionContainer>
-        <ExplorerSectionSummary>
-          <Typography
-            variant={"caption"}
-            fontSize={"1rem"}
-            textTransform={"uppercase"}
-          >
-            Open Editors
-          </Typography>
-        </ExplorerSectionSummary>
-        <AccordionDetails>
-          <Typography>Main.java</Typography>
-        </AccordionDetails>
-      </ExplorerSectionContainer>
+
+      {/*  source folder  */}
+      <ExplorerSectionSummary>
+        <VSCodeIcon iconName={"chevron-down"} style={ExplorerSectionSummaryIconStyle} />
+        <ExplorerSectionSummaryHeader>
+          Open Editors
+        </ExplorerSectionSummaryHeader>
+      </ExplorerSectionSummary>
+
+      {/*  source folder contents  */}
+      <VSCodeExplorerFiles files={files}/>
+
+      {/*  outline  */}
+      <ExplorerSectionSummary>
+        <VSCodeIcon iconName={"chevron-right"} style={ExplorerSectionSummaryIconStyle} />
+        <ExplorerSectionSummaryHeader>
+          Outline
+        </ExplorerSectionSummaryHeader>
+      </ExplorerSectionSummary>
+
+      {/*  timeline  */}
+      <ExplorerSectionSummary>
+        <VSCodeIcon iconName={"chevron-right"} style={ExplorerSectionSummaryIconStyle} />
+        <ExplorerSectionSummaryHeader>
+          Timeline
+        </ExplorerSectionSummaryHeader>
+      </ExplorerSectionSummary>
+
     </Box>
   );
 }

--- a/src/components/VSCodeExplorer/VSCodeExplorerFileItem.tsx
+++ b/src/components/VSCodeExplorer/VSCodeExplorerFileItem.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import { File } from "../../types/FileTypes";
+import { styled } from "@mui/material/styles";
+import { VSCODE_COLORS } from "../../theme/colors";
+
+type Props = {
+  file: File;
+  indentationLevel?: number;
+  children?: React.ReactNode;
+};
+
+const ExplorerFileContainer = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  flexDirection: "row",
+  justifyContent: "flex-start",
+  margin: "0.05rem 0",
+});
+
+const ExplorerFileHeader = styled(Typography)({
+  fontSize: "0.8rem",
+  fontWeight: 500,
+  color: VSCODE_COLORS.explorerText,
+  userSelect: "none",
+});
+
+function VSCodeExplorerFileItem({ file, children }: Props) {
+  return (
+    <Box>
+      <ExplorerFileContainer>
+        <ExplorerFileHeader marginLeft={!file.isFolder ? "1rem" : "0px"} paddingLeft={!file.isFolder ? "20px" : "4px"}>{file.name}</ExplorerFileHeader>
+      </ExplorerFileContainer>
+      {children}
+    </Box>
+  );
+}
+
+export default VSCodeExplorerFileItem;

--- a/src/components/VSCodeExplorer/VSCodeExplorerFiles.tsx
+++ b/src/components/VSCodeExplorer/VSCodeExplorerFiles.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { File } from "../../types/FileTypes";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionProps,
+  AccordionSummary,
+  AccordionSummaryProps,
+  Box
+} from "@mui/material";
+import VSCodeExplorerFileItem from "./VSCodeExplorerFileItem";
+import { styled } from "@mui/material/styles";
+import VsCodeIcon from "../VSCodeIcon";
+import { VSCODE_COLORS } from "../../theme/colors";
+
+type Props = {
+  files?: File[];
+};
+
+const ExplorerSectionContainer = styled((props: AccordionProps) => (
+  <Accordion square disableGutters elevation={0} {...props} />
+))(({
+  backgroundColor: "inherit",
+  color: "inherit",
+  border: "none",
+}));
+
+const ExplorerSectionSummary = styled((props: AccordionSummaryProps) => (
+  <AccordionSummary
+    expandIcon={<VsCodeIcon iconName={"chevron-right"} style={{ color: VSCODE_COLORS.explorerText }} />}
+    {...props}
+  />
+))(({ theme }) => ({
+  flexDirection: "row-reverse",
+  minHeight: 0,
+  height: "fit-content",
+  "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
+    transform: "rotate(90deg)",
+  },
+  "& .MuiAccordionSummary-content": {
+    marginLeft: theme.spacing(1),
+    margin: 0,
+  },
+}));
+
+const ExplorerSectionDetails = styled(AccordionDetails)({
+  margin: "0 0.5rem",
+  padding: 0,
+});
+
+function VSCodeExplorerFiles({ files }: Props) {
+  const mapFiles = (files?: File[]) =>
+    files && files.map((file, index) =>
+      file.isFolder ? (
+        <ExplorerSectionContainer variant={"outlined"} square>
+          <ExplorerSectionSummary>
+            <VSCodeExplorerFileItem key={`folder-${file.name}-${index}`} file={file} />
+          </ExplorerSectionSummary>
+          <ExplorerSectionDetails>
+            {mapFiles(file.folderContents)}
+          </ExplorerSectionDetails>
+        </ExplorerSectionContainer>
+      ) : (
+        <VSCodeExplorerFileItem key={`item-${index}-${file.name}`} file={file} />
+      )
+    );
+
+  return (
+    <Box
+      display={"flex"}
+      flexGrow={1}
+      flexDirection={"column"}
+      justifyContent={"flex-start"}
+      alignItems={"flex-start"}
+    >
+      {mapFiles(files)}
+    </Box>
+  );
+}
+
+export default VSCodeExplorerFiles;

--- a/src/components/VSCodeExplorer/index.js
+++ b/src/components/VSCodeExplorer/index.js
@@ -1,0 +1,3 @@
+import VSCodeExplorer from "./VSCodeExplorer";
+
+export default VSCodeExplorer;

--- a/src/components/VSCodeIcon/VSCodeIcon.tsx
+++ b/src/components/VSCodeIcon/VSCodeIcon.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import "@vscode/codicons/dist/codicon.css";
+
+type Props = {
+  iconName: string;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+function VsCodeIcon({ iconName, className, style }: Props) {
+  return (
+    <i className={`codicon codicon-${iconName} ${className}`}
+       style={{ display: "flex", alignItems: "center", justifyContent: "center", ...style }} />
+  );
+}
+
+export default VsCodeIcon;

--- a/src/components/VSCodeIcon/index.js
+++ b/src/components/VSCodeIcon/index.js
@@ -1,0 +1,3 @@
+import VSCodeIcon from "./VSCodeIcon";
+
+export default VSCodeIcon;

--- a/src/components/VSCodeSidebar/VSCodeSidebar.tsx
+++ b/src/components/VSCodeSidebar/VSCodeSidebar.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { Box } from "@mui/material";
 
-import FileCopyIcon from "@mui/icons-material/FileCopy";
-import SearchIcon from "@mui/icons-material/Search";
 import { VSCODE_COLORS } from "../../theme/colors";
+import VSCodeIcon from "../VSCodeIcon";
+
+const VSCodeIconStyle: React.CSSProperties = {
+  padding: "0.8rem 0",
+  width: "100%",
+  fontSize: "1.5rem",
+};
 
 function VsCodeSidebar() {
   return (
@@ -11,13 +16,22 @@ function VsCodeSidebar() {
       display={"flex"}
       flexDirection={"column"}
       alignItems={"center"}
-      width={"5rem"}
-      padding={"1rem"}
+      width={"3.5rem"}
       bgcolor={VSCODE_COLORS.lightGrey}
       color={VSCODE_COLORS.sidebarIcon}
     >
-      <FileCopyIcon fontSize={"large"} />
-      <SearchIcon fontSize={"large"} />
+      <VSCodeIcon iconName={"files"} style={{ ...VSCodeIconStyle, color: "white", borderLeft: "2px solid white" }} />
+      <VSCodeIcon iconName={"search"} style={VSCodeIconStyle} />
+      <VSCodeIcon iconName={"source-control"} style={VSCodeIconStyle} />
+      <VSCodeIcon iconName={"debug-alt"} style={VSCodeIconStyle} />
+      <VSCodeIcon iconName={"remote-explorer"} style={VSCodeIconStyle} />
+      <VSCodeIcon iconName={"extensions"} style={VSCodeIconStyle} />
+
+      {/* Placeholder for empty space in between. */}
+      <Box flexGrow={1}></Box>
+
+      <VSCodeIcon iconName={"account"} style={VSCodeIconStyle} />
+      <VSCodeIcon iconName={"settings-gear"} style={VSCodeIconStyle} />
     </Box>
   );
 }

--- a/src/components/VSCodeSidebar/VSCodeSidebar.tsx
+++ b/src/components/VSCodeSidebar/VSCodeSidebar.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Box } from "@mui/material";
+
+import FileCopyIcon from "@mui/icons-material/FileCopy";
+import SearchIcon from "@mui/icons-material/Search";
+import { VSCODE_COLORS } from "../../theme/colors";
+
+function VsCodeSidebar() {
+  return (
+    <Box
+      display={"flex"}
+      flexDirection={"column"}
+      alignItems={"center"}
+      width={"5rem"}
+      padding={"1rem"}
+      bgcolor={VSCODE_COLORS.lightGrey}
+      color={VSCODE_COLORS.sidebarIcon}
+    >
+      <FileCopyIcon fontSize={"large"} />
+      <SearchIcon fontSize={"large"} />
+    </Box>
+  );
+}
+
+export default VsCodeSidebar;

--- a/src/components/VSCodeSidebar/index.js
+++ b/src/components/VSCodeSidebar/index.js
@@ -1,0 +1,3 @@
+import VSCodeSidebar from "./VSCodeSidebar";
+
+export default VSCodeSidebar;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -9,12 +9,12 @@ import {useNavigate} from "react-router-dom";
 function HomePage() {
     const navigate = useNavigate();
 
-    const onPlaySoloClick = () => {
-        navigate("/solo");
+    const handleStartModule = () => {
+        navigate("/play");
     };
 
-    const onPlayMultiplayerClick = () => {
-        navigate("/multiplayer");
+    const handleStartTests = () => {
+        navigate("/tests");
     };
 
     return (
@@ -25,10 +25,10 @@ function HomePage() {
                 </Typography>
             </MainContentsContainer>
             <div className={classes.ButtonContainer}>
-                <CustomButton onClick={onPlaySoloClick}>
+                <CustomButton onClick={handleStartModule}>
                     Start Module
                 </CustomButton>
-                <CustomButton onClick={onPlayMultiplayerClick}>
+                <CustomButton onClick={handleStartTests}>
                     Start Tests
                 </CustomButton>
             </div>

--- a/src/pages/VSCodePage/VSCodePage.tsx
+++ b/src/pages/VSCodePage/VSCodePage.tsx
@@ -1,5 +1,12 @@
 import React, { useState } from "react";
 import Editor from "@monaco-editor/react";
+import AppWindowFrame from "../../components/AppWindowFrame";
+import { VSCODE_COLORS } from "../../theme/colors";
+import VSCodeSidebar from "../../components/VSCodeSidebar";
+import VSCodeExplorer from "../../components/VSCodeExplorer";
+import { Box, Breadcrumbs, Typography } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 
 function VSCodePage() {
   const [code, setCode] = useState(`class Solution {
@@ -16,24 +23,71 @@ function VSCodePage() {
     }
 }`);
 
+  const breadcrumbs = [
+    <Typography key={1} color={"inherit"}>codebase</Typography>,
+    <Typography key={2} color={"inherit"}>Main.java</Typography>
+  ];
+
   return (
-    <div
-      style={{
-        width: "100vw",
-        height: "100%"
-      }}
-    >
-      <Editor
-        options={{
-          fontSize: "14px",
-        }}
-        height="100%"
-        defaultLanguage="java"
-        theme="vs-dark"
-        defaultValue={code}
-        onChange={(value) => value && setCode(value)}
-      />
-    </div>
+    <AppWindowFrame frameColor={VSCODE_COLORS.frame} title={"Main.java — LGI Codebase"}>
+      <VSCodeSidebar />
+      <VSCodeExplorer />
+      <Box
+        display={"flex"}
+        flexDirection={"column"}
+        height={"100%"}
+        flexGrow={1}
+        color={"white"}
+        bgcolor={VSCODE_COLORS.textarea}
+      >
+        <Box
+          display={"flex"}
+          flexDirection={"row"}
+          justifyContent={"left"}
+          alignItems={"center"}
+        >
+          <Box
+            display={"flex"}
+            justifyContent={"center"}
+            alignItems={"center"}
+            padding={"0.5rem 1rem"}
+          >
+            <Typography
+              variant={"caption"}
+              fontSize={"0.75rem"}
+              fontWeight={500}
+              marginRight={1}
+            >
+              Main.java
+            </Typography>
+
+            <CloseIcon fontSize={"small"} />
+          </Box>
+        </Box>
+
+        <Breadcrumbs
+          separator={<NavigateNextIcon fontSize="small" />}
+          aria-label="breadcrumb"
+          color={VSCODE_COLORS.breadcrumbsText}
+          sx={{
+            padding: "0.25rem 1rem",
+          }}
+        >
+          {breadcrumbs}
+        </Breadcrumbs>
+
+        <Editor
+          options={{
+            fontSize: "14px",
+          }}
+          height="100%"
+          defaultLanguage="java"
+          theme="vs-dark"
+          defaultValue={code}
+          onChange={(value) => value && setCode(value)}
+        />
+      </Box>
+    </AppWindowFrame>
   );
 }
 

--- a/src/pages/VSCodePage/VSCodePage.tsx
+++ b/src/pages/VSCodePage/VSCodePage.tsx
@@ -58,6 +58,9 @@ function VSCodePage() {
     <Typography key={2} color={"inherit"}>{fileName}</Typography>
   ];
 
+  const preventSave = (e: React.KeyboardEvent<HTMLDivElement>) =>
+    e.key === "s" && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey) && e.preventDefault();
+
   return (
     <AppWindowFrame frameColor={VSCODE_COLORS.frame} title={`${fileName} — LGI Codebase`}>
       <VSCodeSidebar />
@@ -69,6 +72,7 @@ function VSCodePage() {
         flexGrow={1}
         color={"white"}
         bgcolor={VSCODE_COLORS.textarea}
+        onKeyDown={preventSave}
       >
         <Box
           display={"flex"}

--- a/src/pages/VSCodePage/VSCodePage.tsx
+++ b/src/pages/VSCodePage/VSCodePage.tsx
@@ -7,31 +7,61 @@ import VSCodeExplorer from "../../components/VSCodeExplorer";
 import { Box, Breadcrumbs, Typography } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+import { File } from "../../types/FileTypes";
+
+const dummyfiles: File[] = [
+  {
+    name: "new folder",
+    isFolder: true,
+    folderContents: [
+      {
+        name: "new folder2",
+        isFolder: true,
+        folderContents: [
+          {
+            name: "new file3.md",
+            isFolder: false,
+            contents: "hhehe",
+          }
+        ]
+      },
+      {
+        name: "new file.md",
+        isFolder: false,
+        contents: "hhehe",
+      },
+      {
+        name: "new file2.md",
+        isFolder: false,
+        contents: "hhehe",
+      },
+    ],
+  },
+  {
+    name: "dummy.txt",
+    isFolder: false,
+    contents: "hehe xd hello world",
+  },
+  {
+    name: "main.py",
+    isFolder: false,
+    contents: "def main():\n    print('hello world')",
+  }
+];
 
 function VSCodePage() {
-  const [code, setCode] = useState(`class Solution {
-    public boolean isSubsequence(String s, String t) {
-        if (s.length() == 0) return true;
-        int i = 0;
-        for (int j = 0; j < t.length(); j++) {
-            if (s.charAt(i) == t.charAt(j)) {
-                i++;
-                if (i >= s.length()) return true;
-            }
-        }
-        return false;
-    }
-}`);
+  const [code, setCode] = useState(dummyfiles[2].contents);
+  const [fileName, setFileName] = useState("main.py");
 
   const breadcrumbs = [
     <Typography key={1} color={"inherit"}>codebase</Typography>,
-    <Typography key={2} color={"inherit"}>Main.java</Typography>
+    <Typography key={2} color={"inherit"}>{fileName}</Typography>
   ];
 
   return (
-    <AppWindowFrame frameColor={VSCODE_COLORS.frame} title={"Main.java — LGI Codebase"}>
+    <AppWindowFrame frameColor={VSCODE_COLORS.frame} title={`${fileName} — LGI Codebase`}>
       <VSCodeSidebar />
-      <VSCodeExplorer />
+      <VSCodeExplorer files={dummyfiles} />
       <Box
         display={"flex"}
         flexDirection={"column"}
@@ -45,20 +75,21 @@ function VSCodePage() {
           flexDirection={"row"}
           justifyContent={"left"}
           alignItems={"center"}
+          bgcolor={VSCODE_COLORS.explorerGrey}
         >
           <Box
             display={"flex"}
             justifyContent={"center"}
             alignItems={"center"}
             padding={"0.5rem 1rem"}
+            bgcolor={VSCODE_COLORS.textarea}
           >
             <Typography
-              variant={"caption"}
-              fontSize={"0.75rem"}
-              fontWeight={500}
+              fontSize={"0.8rem"}
+              fontWeight={600}
               marginRight={1}
             >
-              Main.java
+              {fileName}
             </Typography>
 
             <CloseIcon fontSize={"small"} />
@@ -81,7 +112,7 @@ function VSCodePage() {
             fontSize: "14px",
           }}
           height="100%"
-          defaultLanguage="java"
+          defaultLanguage="python"
           theme="vs-dark"
           defaultValue={code}
           onChange={(value) => value && setCode(value)}

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -16,6 +16,7 @@ const VSCODE_COLORS = {
   explorerText: "#CCCCCC",
   changedText: "#E2C08D",
   breadcrumbsText: "#A9A9A9",
+  explorerDivider: "#454545",
 };
 
 export { SLACK_COLORS, VSCODE_COLORS };

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -6,4 +6,16 @@ const SLACK_COLORS = {
   sideBarTextColor: "#E0E0E0",
 };
 
-export { SLACK_COLORS };
+const VSCODE_COLORS = {
+  explorerGrey: "#252526",
+  lightGrey: "#333333",
+  frame: "#3C3C3C",
+  textarea: "#1E1E1E",
+  selectedGrey: "#37373D",
+  sidebarIcon: "#858585",
+  explorerText: "#CCCCCC",
+  changedText: "#E2C08D",
+  breadcrumbsText: "#A9A9A9",
+};
+
+export { SLACK_COLORS, VSCODE_COLORS };

--- a/src/types/FileTypes.ts
+++ b/src/types/FileTypes.ts
@@ -1,0 +1,6 @@
+export type File = {
+  name: string;
+  isFolder: boolean;
+  contents?: string;
+  folderContents?: File[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,6 +1577,36 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@microsoft/fast-element@^1.10.2", "@microsoft/fast-element@^1.6.2", "@microsoft/fast-element@^1.9.0":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.10.2.tgz#34a2faa8a97608e1b7c8024b9aed3deddd5c6ad8"
+  integrity sha512-Nh80AEx/caDe4jhFYNT75sTG4k6MWy1N6XfgyhmejAX0ylivYy0M78WI2JgQOqi2ZRozCiNcpAPLVhYyAVN9sA==
+
+"@microsoft/fast-foundation@^2.38.0", "@microsoft/fast-foundation@^2.41.1":
+  version "2.46.9"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.46.9.tgz#a4d4ce50861f71aaef5697746e87b8f66b280507"
+  integrity sha512-jgkVT7bAWIV844eDj3V9cmYFsRIcJ8vMuB4h2SlkJ9EmFbCfimvh6RyAhsHv+bC6QZSS0N0bpZHm5A5QsWgi3Q==
+  dependencies:
+    "@microsoft/fast-element" "^1.10.2"
+    "@microsoft/fast-web-utilities" "^5.4.1"
+    tabbable "^5.2.0"
+    tslib "^1.13.0"
+
+"@microsoft/fast-react-wrapper@^0.1.18":
+  version "0.1.48"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz#aa89c0dfb703c2f71619c536de2342e28b40b8c9"
+  integrity sha512-9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==
+  dependencies:
+    "@microsoft/fast-element" "^1.9.0"
+    "@microsoft/fast-foundation" "^2.41.1"
+
+"@microsoft/fast-web-utilities@^5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz#8e3082ee2ff2b5467f17e7cb1fb01b0e4906b71f"
+  integrity sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==
+  dependencies:
+    exenv-es6 "^1.1.1"
+
 "@monaco-editor/loader@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.3.2.tgz#04effbb87052d19cd7d3c9d81c0635490f9bb6d8"
@@ -2388,6 +2418,20 @@
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.7.tgz#443a9b6df87f2f2961b74d42997ce723a7078623"
   integrity sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==
+
+"@vscode/codicons@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.31.tgz#1dc56f9442c3928b1c851965cf360e7e051e6511"
+  integrity sha512-fldpXy7pHsQAMlU1pnGI23ypQ6xLk5u6SiABMFoAmlj4f2MR0iwg7C19IB1xvAEGG+dkxOfRSrbKF8ry7QqGQA==
+
+"@vscode/webview-ui-toolkit@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.0.tgz#b3d13e0a7f4af8df91009a5781faad2bf0e07a80"
+  integrity sha512-/qaHYZXqvIKkao54b7bLzyNH8BC+X4rBmTUx1MvcIiCjqRMxml0BCpqJhnDpfrCb0IOxXRO8cAy1eB5ayzQfBA==
+  dependencies:
+    "@microsoft/fast-element" "^1.6.2"
+    "@microsoft/fast-foundation" "^2.38.0"
+    "@microsoft/fast-react-wrapper" "^0.1.18"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -4418,6 +4462,11 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+exenv-es6@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exenv-es6/-/exenv-es6-1.1.1.tgz#80b7a8c5af24d53331f755bac07e84abb1f6de67"
+  integrity sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==
 
 exit@^0.1.2:
   version "0.1.2"
@@ -8423,6 +8472,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tabbable@^5.2.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
+  integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
+
 tailwindcss@^3.0.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.1.3.tgz#b9ef2c1ae537c339679e8e89635af8e143d1c7eb"
@@ -8589,7 +8643,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
+tslib@^1.13.0, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
VSCode screen brings in two libraries to make it possible.
One is `@vscode/codicon` and the other is `@vscode/webview-ui-toolkit`.
Both libraries are from microsoft, and are used in VS Code right now. 

Minor features may further need to be adjusted but overall it is deemed enough to be considered implemented.